### PR TITLE
Update ClientRepository.php

### DIFF
--- a/app/Repositories/Client/ClientRepository.php
+++ b/app/Repositories/Client/ClientRepository.php
@@ -48,7 +48,7 @@ class ClientRepository implements ClientRepositoryContract
      */
     public function getAllClientsCount()
     {
-        return Client::all()->count();
+        return Client::count();
     }
 
     /**


### PR DESCRIPTION
Big client tables will force to load all objects to the memory and we will get an 'out of memory' issue. Using Model::count(); we do not load the entire collection and the result will be the same for the count purpouse.