### PR TITLE
Update Dockerfile

### DIFF
--- a/.docker/flarepoint-php/Dockerfile
+++ b/.docker/flarepoint-php/Dockerfile
@@ -12,7 +12,7 @@ RUN docker-php-source extract \
                               libfreetype6-dev \
                               libjpeg62-turbo-dev \
                               libmcrypt-dev \
-                              libpng12-dev \
+                              libpng-dev \
 	&& docker-php-ext-install pdo pdo_mysql zip \
 	&& docker-php-ext-install -j$(nproc) iconv mcrypt \
 	&& docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \


### PR DESCRIPTION
Change dependency from libpng12-dev to libpng-dev to fix the 'E: Package 'libpng12-dev' has no installation candidate' error when running docker-compose up