### PR TITLE
  Unable to prepare route [leads/updatefollowup/{external_id}] for se…

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -92,7 +92,6 @@ Route::group(['middleware' => ['auth']], function () {
         Route::patch('/updatefollowup/{external_id}', 'LeadsController@updateFollowup')->name('lead.followup');
         Route::post('/updateassign/{external_id}', 'LeadsController@updateAssign');
         Route::post('/updatestatus/{external_id}', 'LeadsController@updateStatus');
-        Route::post('/updatefollowup/{external_id}', 'LeadsController@updateFollowup')->name('lead.followup');
         Route::get('/create/{client_external_id}', 'LeadsController@create')->name('client.lead.create');
 
         Route::post('/covert-to-qualified/{lead}', 'LeadsController@convertToQualifiedLead')->name('lead.convert.qualified');


### PR DESCRIPTION
  Unable to prepare route [leads/updatefollowup/{external_id}] for serialization. Another route has already been assigned name [lead.followup].

Fixes #180 

There are two routes with name `lead.followup`. But only the route with method `PATCH` is used. 